### PR TITLE
Change tx behavior of StateVec::with_capacity

### DIFF
--- a/src/state/state_vec.rs
+++ b/src/state/state_vec.rs
@@ -89,7 +89,7 @@ where
     pub fn with_capacity(n: usize) -> Self {
         Self {
             value: Arc::new(RwLock::new(Vec::with_capacity(n))),
-            tx: Arc::new(RwLock::new(Vec::with_capacity(n))),
+            tx: Arc::new(RwLock::new(Vec::new()))),
         }
     }
 }

--- a/src/state/state_vec.rs
+++ b/src/state/state_vec.rs
@@ -89,7 +89,7 @@ where
     pub fn with_capacity(n: usize) -> Self {
         Self {
             value: Arc::new(RwLock::new(Vec::with_capacity(n))),
-            tx: Arc::new(RwLock::new(Vec::new()))),
+            tx: Arc::new(RwLock::new(Vec::new())),
         }
     }
 }


### PR DESCRIPTION
If my understanding is correct, it would be very rare for a StateVec to have more than a couple of `tx` instances on it. If a user wanted to initialize the vec with 1000 items they would likely not also mean it to be initialized for it to have 1000 attached listeners.